### PR TITLE
Add ocorrencias model, CRUD, service, endpoint

### DIFF
--- a/backend/app/api/v1/__init__.py
+++ b/backend/app/api/v1/__init__.py
@@ -1,6 +1,8 @@
 from fastapi import APIRouter
 
-from app.api.v1.endpoints import users
+
+from app.api.v1.endpoints import users, ocorrencias
 
 api_router = APIRouter(prefix="/api/v1")
 api_router.include_router(users.router)
+api_router.include_router(ocorrencias.router)

--- a/backend/app/api/v1/endpoints/ocorrencias.py
+++ b/backend/app/api/v1/endpoints/ocorrencias.py
@@ -1,0 +1,33 @@
+from fastapi import APIRouter, Depends, status, UploadFile, File, Form
+from sqlalchemy.orm import Session
+from typing import Optional
+from app.api.deps import get_db
+from app.schemas.ocorrencia import OcorrenciaCreate, OcorrenciaRead
+from app.services.ocorrencia import registrar_ocorrencia
+
+router = APIRouter(prefix="/ocorrencias", tags=["Ocorrências"])
+
+@router.post(
+    "/",
+    response_model=OcorrenciaRead,
+    status_code=status.HTTP_201_CREATED,
+    summary="Registrar nova ocorrência",
+    description="Registra uma nova ocorrência com mídia, descrição, localização e tipo.",
+)
+async def criar_ocorrencia(
+    descricao: str = Form(...),
+    localizacao: str = Form(...),
+    tipo: str = Form(...),
+    midia: Optional[UploadFile] = File(None),
+    db: Session = Depends(get_db),
+):
+    # Aqui você pode salvar o arquivo e obter a URL
+    midia_url = None
+    if midia:
+        # Exemplo: salvar em disco ou serviço de arquivos
+        midia_url = f"/static/uploads/{midia.filename}"
+        with open(f"static/uploads/{midia.filename}", "wb") as f:
+            f.write(await midia.read())
+    ocorrencia_in = OcorrenciaCreate(descricao=descricao, localizacao=localizacao, tipo=tipo)
+    ocorrencia = registrar_ocorrencia(db=db, ocorrencia_in=ocorrencia_in, midia_url=midia_url)
+    return ocorrencia

--- a/backend/app/crud/ocorrencia.py
+++ b/backend/app/crud/ocorrencia.py
@@ -1,0 +1,15 @@
+from sqlalchemy.orm import Session
+from app.models.ocorrencia import Ocorrencia, TipoOcorrencia
+from app.schemas.ocorrencia import OcorrenciaCreate
+
+def create_ocorrencia(db: Session, ocorrencia_in: OcorrenciaCreate, midia_url: str = None) -> Ocorrencia:
+    ocorrencia = Ocorrencia(
+        descricao=ocorrencia_in.descricao,
+        localizacao=ocorrencia_in.localizacao,
+        tipo=ocorrencia_in.tipo,
+        midia_url=midia_url,
+    )
+    db.add(ocorrencia)
+    db.commit()
+    db.refresh(ocorrencia)
+    return ocorrencia

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,3 +1,4 @@
 from app.models.user import User
+from app.models.ocorrencia import Ocorrencia
 
-__all__ = ["User"]
+__all__ = ["User", "Ocorrencia"]

--- a/backend/app/models/ocorrencia.py
+++ b/backend/app/models/ocorrencia.py
@@ -1,0 +1,25 @@
+from sqlalchemy import Column, String, DateTime, Enum, ForeignKey, func
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import relationship
+from app.db.database import Base
+import enum
+
+class TipoOcorrencia(str, enum.Enum):
+    esgoto = "esgoto"
+    agua = "agua"
+    mosquito = "mosquito"
+    lixo = "lixo"
+
+class Ocorrencia(Base):
+    __tablename__ = "ocorrencias"
+
+    id = Column(UUID(as_uuid=False), primary_key=True, server_default=func.gen_random_uuid())
+    descricao = Column(String(500), nullable=False)
+    localizacao = Column(String(255), nullable=False)
+    tipo = Column(Enum(TipoOcorrencia), nullable=False)
+    midia_url = Column(String(255), nullable=True)
+    created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+    updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False)
+    # Se quiser associar a um usuário futuramente, adicione o campo abaixo:
+    # usuario_id = Column(UUID(as_uuid=False), ForeignKey("users.id"), nullable=True)
+    # usuario = relationship("User")

--- a/backend/app/schemas/__init__.py
+++ b/backend/app/schemas/__init__.py
@@ -1,3 +1,4 @@
 from app.schemas.user import UserCreate, UserRead, UserUpdate
+from app.schemas.ocorrencia import OcorrenciaCreate, OcorrenciaRead
 
-__all__ = ["UserCreate", "UserRead", "UserUpdate"]
+__all__ = ["UserCreate", "UserRead", "UserUpdate", "OcorrenciaCreate", "OcorrenciaRead"]

--- a/backend/app/schemas/ocorrencia.py
+++ b/backend/app/schemas/ocorrencia.py
@@ -1,0 +1,28 @@
+from datetime import datetime
+from uuid import UUID
+from pydantic import BaseModel, Field
+from typing import Optional
+from enum import Enum
+
+class TipoOcorrencia(str, Enum):
+    esgoto = "esgoto"
+    agua = "agua"
+    mosquito = "mosquito"
+    lixo = "lixo"
+
+class OcorrenciaBase(BaseModel):
+    descricao: str = Field(..., min_length=5, max_length=500)
+    localizacao: str = Field(..., min_length=3, max_length=255)
+    tipo: TipoOcorrencia
+
+class OcorrenciaCreate(OcorrenciaBase):
+    pass
+
+class OcorrenciaRead(OcorrenciaBase):
+    id: UUID
+    midia_url: Optional[str] = None
+    created_at: datetime
+    updated_at: datetime
+
+    class Config:
+        orm_mode = True

--- a/backend/app/services/ocorrencia.py
+++ b/backend/app/services/ocorrencia.py
@@ -1,0 +1,7 @@
+from sqlalchemy.orm import Session
+from app.schemas.ocorrencia import OcorrenciaCreate
+from app.models.ocorrencia import Ocorrencia
+from app.crud.ocorrencia import create_ocorrencia
+
+def registrar_ocorrencia(db: Session, ocorrencia_in: OcorrenciaCreate, midia_url: str = None) -> Ocorrencia:
+    return create_ocorrencia(db=db, ocorrencia_in=ocorrencia_in, midia_url=midia_url)


### PR DESCRIPTION
Introduce full support for 'ocorrencias' (incidents): adds a new SQLAlchemy model (Ocorrencia) and TipoOcorrencia enum, Pydantic schemas (OcorrenciaCreate, OcorrenciaRead), CRUD function (create_ocorrencia), and a service wrapper (registrar_ocorrencia). Adds an API endpoint to POST /api/v1/ocorrencias which accepts form data and optional file upload (saves to static/uploads as a simple example). Also registers the ocorrencias router in api v1 and exports the new model/schemas from their respective __init__ modules.